### PR TITLE
Greeter and Twin

### DIFF
--- a/tests/Interop.Tests/Slice/ChatBot.cs
+++ b/tests/Interop.Tests/Slice/ChatBot.cs
@@ -6,17 +6,17 @@ using IceRpc.Slice;
 
 namespace Interop.Tests.Slice;
 
-/// <summary>A basic, reusable implementation of IHelloService.</summary>
-public class ChatBot : Service, IHelloService
+/// <summary>A basic, reusable implementation of <see cref="GreeterDisp_" />.</summary>
+public class ChatBot : GreeterDisp_
 {
-    public ValueTask<string> SayHelloAsync(
+    public override string greet(string name, Current? current = null) => $"Hello, {name}!";
+}
+
+/// <summary>A basic, reusable implementation of <see cref="IGreeterService" />.</summary>
+public class ChatBotTwin : Service, IGreeterService
+{
+    public ValueTask<string> GreetAsync(
         string name,
         IFeatureCollection features,
         CancellationToken cancellationToken) => new($"Hello, {name}!");
-}
-
-/// <summary>A basic, reusable implementation of HelloDisp_.</summary>
-public class IceChatBot : HelloDisp_
-{
-    public override string sayHello(string name, Current? current = null) => $"Hello, {name}!";
 }

--- a/tests/Interop.Tests/Slice/Greeter.ice
+++ b/tests/Interop.Tests/Slice/Greeter.ice
@@ -6,9 +6,9 @@ module Interop
     {
         module Slice
         {
-            interface Hello
+            interface Greeter
             {
-                string sayHello(string name);
+                string greet(string name);
             }
         }
     }

--- a/tests/Interop.Tests/Slice/Greeter.slice
+++ b/tests/Interop.Tests/Slice/Greeter.slice
@@ -4,6 +4,6 @@ encoding = Slice1
 
 module Interop::Tests::Slice
 
-interface Hello {
-    sayHello(name: string) -> string
+interface Greeter {
+    greet(name: string) -> string
 }

--- a/tests/Interop.Tests/Slice/IceObjectTests.cs
+++ b/tests/Interop.Tests/Slice/IceObjectTests.cs
@@ -28,7 +28,7 @@ public class IceObjectTests
     {
         using Ice.Communicator communicator = Ice.Util.initialize();
         Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("test", "tcp -h 127.0.0.1 -p 0");
-        _ = adapter.add(new IceChatBot(), new Ice.Identity("hello", ""));
+        _ = adapter.add(new ChatBot(), new Ice.Identity("hello", ""));
         adapter.activate();
 
         await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
@@ -41,13 +41,13 @@ public class IceObjectTests
     [Test]
     public async Task Ice_isA_on_IceRPC_service()
     {
-        await using var server = new Server(new ChatBot(), new Uri("ice://127.0.0.1:0"));
+        await using var server = new Server(new ChatBotTwin(), new Uri("ice://127.0.0.1:0"));
         ServerAddress serverAddress = server.Listen();
 
         using Ice.Communicator communicator = Ice.Util.initialize();
         Ice.ObjectPrx proxy = communicator.CreateObjectPrx("hello", serverAddress);
 
-        Assert.That(async () => await proxy.ice_isAAsync(typeof(IHello).GetSliceTypeId()), Is.True);
+        Assert.That(async () => await proxy.ice_isAAsync(typeof(IGreeter).GetSliceTypeId()), Is.True);
     }
 
     /// <summary>An IceRPC client sends ice_isA to an Ice object.</summary>
@@ -56,13 +56,13 @@ public class IceObjectTests
     {
         using Ice.Communicator communicator = Ice.Util.initialize();
         Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("test", "tcp -h 127.0.0.1 -p 0");
-        _ = adapter.add(new IceChatBot(), new Ice.Identity("hello", ""));
+        _ = adapter.add(new ChatBot(), new Ice.Identity("hello", ""));
         adapter.activate();
 
         await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
         var proxy = new IceObjectProxy(clientConnection, new Uri("ice:/hello"));
 
-        Assert.That(async () => await proxy.IceIsAAsync(typeof(IHello).GetSliceTypeId()!), Is.True);
+        Assert.That(async () => await proxy.IceIsAAsync(typeof(IGreeter).GetSliceTypeId()!), Is.True);
     }
 
     /// <summary>Verifies that ice_ids return the same value with Ice and IceRPC.</summary>
@@ -71,13 +71,13 @@ public class IceObjectTests
     {
         using Ice.Communicator communicator = Ice.Util.initialize();
         Ice.ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("test", "tcp -h 127.0.0.1 -p 0");
-        _ = adapter.add(new IceChatBot(), new Ice.Identity("hello", ""));
+        _ = adapter.add(new ChatBot(), new Ice.Identity("hello", ""));
         adapter.activate();
 
         await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
         var proxy1 = new IceObjectProxy(clientConnection, new Uri("ice:/hello"));
 
-        await using var server = new Server(new ChatBot(), new Uri("ice://127.0.0.1:0"));
+        await using var server = new Server(new ChatBotTwin(), new Uri("ice://127.0.0.1:0"));
         ServerAddress serverAddress = server.Listen();
         Ice.ObjectPrx proxy2 = communicator.CreateObjectPrx("hello", serverAddress);
 

--- a/tests/Interop.Tests/Slice/OperationTests.cs
+++ b/tests/Interop.Tests/Slice/OperationTests.cs
@@ -10,30 +10,30 @@ namespace Interop.Tests.Slice;
 public class OperationTests
 {
     [Test]
-    public async Task SayHello_from_icerpc_client()
+    public async Task Request_from_icerpc_client()
     {
         using Communicator communicator = Util.initialize();
         ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("test", "tcp -h 127.0.0.1 -p 0");
-        _ = adapter.add(new IceChatBot(), Util.stringToIdentity("hello"));
+        _ = adapter.add(new ChatBot(), Util.stringToIdentity("hello"));
         adapter.activate();
 
         await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
-        var proxy = new HelloProxy(clientConnection, new Uri("ice:/hello"));
+        var proxy = new GreeterProxy(clientConnection, new Uri("ice:/hello"));
 
         // Act/Assert
-        Assert.That(async () => await proxy.SayHelloAsync("Alice"), Throws.Nothing);
+        Assert.That(async () => await proxy.GreetAsync("Alice"), Throws.Nothing);
     }
 
     [Test]
-    public async Task SayHello_from_ice_client()
+    public async Task Request_from_ice_client()
     {
-        await using var server = new Server(new ChatBot(), new Uri("ice://127.0.0.1:0"));
+        await using var server = new Server(new ChatBotTwin(), new Uri("ice://127.0.0.1:0"));
         ServerAddress serverAddress = server.Listen();
 
         using Communicator communicator = Util.initialize();
-        HelloPrx proxy = HelloPrxHelper.uncheckedCast(communicator.CreateObjectPrx("hello", serverAddress));
+        GreeterPrx proxy = GreeterPrxHelper.uncheckedCast(communicator.CreateObjectPrx("hello", serverAddress));
 
         // Act/Assert
-        Assert.That(async () => await proxy.sayHelloAsync("Alice"), Throws.Nothing);
+        Assert.That(async () => await proxy.greetAsync("Alice"), Throws.Nothing);
     }
 }


### PR DESCRIPTION
This PR renames Hello/sayHello -> Greeter/greet (see https://github.com/zeroc-ice/icerpc-csharp/issues/2848) and changes the convention for "twin" Ice / IceRpc types to:

Ice => get main/default name, e.g. MyClass, ChatBot
IceRpc => if there is a clash with Ice (pretty common), add Twin suffix, e.g. MyClassTwin and ChatBotTwin.

The Twin (when there is one) is always IceRpc and never Ice.

For Slice definitions, we use `[cs::identifier]` in .slice files to add this Twin suffix.