### PR TITLE
Check ssl server addresses

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,6 +29,42 @@
                 "reveal": "always"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/tests/Interop.Tests/Interop.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/tests/Interop.Tests/Interop.Tests.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/tests/Interop.Tests/Interop.Tests.csproj"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/tests/Interop.Tests/Slice/ServiceAddressTests.cs
+++ b/tests/Interop.Tests/Slice/ServiceAddressTests.cs
@@ -63,8 +63,10 @@ public class ServiceAddressTests
     /// opaque for Ice.</remarks>
     [TestCase("ice://127.0.0.1:10000/hello?transport=tcp")]
     [TestCase("ice://[::1]/hello?transport=ssl")]
-    [TestCase("ice://127.0.0.1:10000/hello?transport=ssl&z&t=10000")] // any t value except 60000 should work
-    [TestCase("ice://127.0.0.1:10000/hello?transport=udp&foo=bar")] // opaque for Ice
+    // Any t value except 60000 should work; since 60000 is the default, it's equivalent (and gets replaced by) no
+    // "t=value" at all.
+    [TestCase("ice://127.0.0.1:10000/hello?transport=ssl&z&t=10000")]
+    [TestCase("ice://127.0.0.1:10000/hello?transport=udp&foo=bar")]
     [TestCase("ice://127.0.0.1:10000/hello?transport=tcp&alt-server=foo?transport=wss&alt-server=bar?transport=xyz")]
     [TestCase("ice:/hello?adapter-id=foo#facet")]
     [TestCase("icerpc://127.0.0.1:10000/hello?transport=tcp")]


### PR DESCRIPTION
This tiny PR improves the server address tests to check ssl endpoints after loading the IceSSL plugin.

Fixes #14.