### PR TITLE
Add request from IceRpc to Ice with empty identity

### DIFF
--- a/tests/Interop.Tests/Slice/OperationTests.cs
+++ b/tests/Interop.Tests/Slice/OperationTests.cs
@@ -18,7 +18,22 @@ public class OperationTests
         adapter.activate();
 
         await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
-        var proxy = new GreeterProxy(clientConnection, new Uri("ice:/hello"));
+        var proxy = new GreeterProxy(clientConnection, new Uri($"ice:/hello"));
+
+        // Act/Assert
+        Assert.That(async () => await proxy.GreetAsync("Alice"), Throws.Nothing);
+    }
+
+    [Test]
+    public async Task Request_from_icerpc_client_with_empty_identity()
+    {
+        using Communicator communicator = Util.initialize();
+        ObjectAdapter adapter = communicator.createObjectAdapterWithEndpoints("test", "tcp -h 127.0.0.1 -p 0");
+        adapter.addDefaultServant(new Chatbot(), ""); // catch-all
+        adapter.activate();
+
+        await using var clientConnection = new ClientConnection(adapter.GetFirstServerAddress());
+        var proxy = new GreeterProxy(clientConnection, new ServiceAddress(Protocol.Ice)); // keep "/" identity-path
 
         // Act/Assert
         Assert.That(async () => await proxy.GreetAsync("Alice"), Throws.Nothing);


### PR DESCRIPTION
This PR shows it's possible for IceRPC to send a request with an empty (null) identity and get Ice to successfully dispatch this request.

The trick here is to use a catch-all default servant. It shows that an empty/null identity target is not totally disallowed with Ice; it's just very hard to use since many methods check that the identity you provide is not null/empty, in particular the ObjectAdapter.add methods.